### PR TITLE
removed effectivePeriod

### DIFF
--- a/PatientAccess/JohnAllen_FullBundle_2022-02-24.json
+++ b/PatientAccess/JohnAllen_FullBundle_2022-02-24.json
@@ -479,9 +479,6 @@
                     ],
                     "text": "Glucose [Moles/volume] in Blood"
                 },
-                "effectivePeriod": {
-                    "start": "2021-03-16T21:12:29.000Z"
-                },
                 "valueQuantity": {
                     "unit": "mmol/l",
                     "system": "http://unitsofmeasure.org",

--- a/PatientAccess/John_Allen_Test_Bundle.json
+++ b/PatientAccess/John_Allen_Test_Bundle.json
@@ -840,9 +840,6 @@
                     ],
                     "text": "Glucose [Moles/volume] in Blood"
                 },
-                "effectivePeriod": {
-                    "start": "2021-03-16T21:12:29.000Z"
-                },
                 "valueQuantity": {
                     "unit": "mmol/l",
                     "system": "http://unitsofmeasure.org",


### PR DESCRIPTION
Hi @kyle1uphealth,

Could you please review?
According to HL7 FHIR, we can't have both effectivePeriod and effectiveDateTime element at the same time so I removed effectivePeriod as it only has "start" and only appears once.

Thanks,
Trang